### PR TITLE
Fix duel bankroll settlement and add tests

### DIFF
--- a/server/src/duel_settlement.ts
+++ b/server/src/duel_settlement.ts
@@ -1,0 +1,27 @@
+import { Bet, Side } from './types.js';
+
+export interface DuelSettlementResult {
+  burned: number;
+  roundPayouts: number;
+  payouts: { uid: string; amount: number }[];
+}
+
+export function calculateDuelSettlement(bets: Bet[], winner?: Side): DuelSettlementResult {
+  const burned = bets.reduce((sum, bet) => sum + bet.amount, 0);
+  const winners = winner ? bets.filter((bet) => bet.side === winner) : [];
+  const totalWinnerStake = winners.reduce((sum, bet) => sum + bet.amount, 0);
+  const winPool = burned * 0.98;
+
+  const payouts: { uid: string; amount: number }[] = [];
+  let roundPayouts = 0;
+
+  if (totalWinnerStake > 0) {
+    for (const bet of winners) {
+      const payout = (bet.amount / totalWinnerStake) * winPool;
+      payouts.push({ uid: bet.uid, amount: payout });
+      roundPayouts += payout;
+    }
+  }
+
+  return { burned, roundPayouts, payouts };
+}

--- a/server/test/duel-settlement.test.js
+++ b/server/test/duel-settlement.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateDuelSettlement } from '../dist/duel_settlement.js';
+
+const nearlyEqual = (a, b, epsilon = 1e-9) => Math.abs(a - b) < epsilon;
+
+test('distributes duel pool to the winning side while preserving rake accounting', () => {
+  const bets = [
+    { uid: 'winner-1', amount: 150, side: 'A' },
+    { uid: 'winner-2', amount: 50, side: 'A' },
+    { uid: 'loser', amount: 100, side: 'B' }
+  ];
+
+  const { burned, roundPayouts, payouts } = calculateDuelSettlement(bets, 'A');
+
+  assert.equal(burned, 300);
+  assert.ok(nearlyEqual(roundPayouts, 294));
+  assert.equal(payouts.length, 2);
+  const payoutMap = new Map(payouts.map((p) => [p.uid, p.amount]));
+  assert.ok(nearlyEqual(payoutMap.get('winner-1') ?? 0, 220.5));
+  assert.ok(nearlyEqual(payoutMap.get('winner-2') ?? 0, 73.5));
+  assert.ok(nearlyEqual(burned - roundPayouts, 6));
+});
+
+test('handles rounds with no winners without distributing payouts', () => {
+  const bets = [
+    { uid: 'loser-1', amount: 75, side: 'A' },
+    { uid: 'loser-2', amount: 25, side: 'A' }
+  ];
+
+  const { burned, roundPayouts, payouts } = calculateDuelSettlement(bets, 'B');
+
+  assert.equal(burned, 100);
+  assert.equal(roundPayouts, 0);
+  assert.deepEqual(payouts, []);
+  assert.equal(burned - roundPayouts, 100);
+});


### PR DESCRIPTION
## Summary
- calculate duel settlement payouts via a shared helper and remove incremental bankroll deductions
- apply a single bankroll adjustment using the wager pool and aggregated payouts while keeping jackpot and RTP calculations intact
- add unit coverage for duel rounds with both winning and losing outcomes

## Testing
- npm run build
- node --test test/duel-bet-validation.test.js test/duel-settlement.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d11049a05c832088294dc43862fcee