### PR TITLE
feat: allow configuring client websocket endpoint

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,16 @@
+# Clash Dual Client
+
+## WebSocket configuration
+
+- `VITE_WS_URL` — optional WebSocket endpoint for the frontend.
+  - Takes precedence over the inferred URL from `window.location`.
+  - Set it in `.env` or your deployment environment, for example `VITE_WS_URL=wss://example.com/ws`.
+  - When not provided, the client connects to the same origin. During local development it falls back to `ws://<hostname>:8081/ws`.
+
+## Scripts
+
+```bash
+npm run dev      # start Vite dev server
+npm run build    # type-check and build for production
+npm run preview  # locally preview the production build
+```

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- allow overriding the frontend WebSocket endpoint via `VITE_WS_URL` with sensible fallbacks for production and local dev
- document the new environment variable and available client scripts in a dedicated README
- add the Vite type shim so TypeScript recognises `import.meta.env`

## Testing
- `VITE_WS_URL=ws://127.0.0.1:8081/ws npm run build`
- Dev client connected to `ws://127.0.0.1:8081/ws` via Playwright (server logged `[WS] client connected`)
- Preview build connected to `ws://127.0.0.1:8081/ws` via Playwright (server logged `[WS] client connected`)

------
https://chatgpt.com/codex/tasks/task_e_68d11739b980832089a95cb2a9b880ec