### PR TITLE
Handle non-interactive sudo in deploy automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,14 @@ jobs:
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          SUDO_PASSWORD: ${{ secrets.SUDO_PASSWORD }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           port: ${{ secrets.SSH_PORT || '22' }}
           key: ${{ secrets.SSH_KEY }}
+          envs: SUDO_PASSWORD
           script: |
             echo "[GH-Actions] Start deploy"
             /srv/clash-dual/scripts/deploy.sh


### PR DESCRIPTION
## Summary
- add a helper in deploy.sh to run privileged commands without an interactive sudo prompt
- pass the SUDO_PASSWORD secret through the deploy GitHub Action so remote sudo calls receive the password

## Testing
- bash -n scripts/deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68d130ba96b88320a528cb7f4bbd4732