### PR TITLE
Handle invalid PORT env value with fallback

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,7 +5,23 @@ import { newCrashRound, tickCrash, transitionCrash, addBetCrash, canBet as canBe
 import { newDuelRound, addBetDuel, transitionDuel } from './game_duel_ab.js';
 import { calculateDuelSettlement } from './duel_settlement.js';
 
-const PORT = process.env.PORT ? Number(process.env.PORT) : 8081;
+const DEFAULT_PORT = 8081;
+
+function resolvePort(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  console.warn(`[WS] Invalid PORT environment value "${raw}", falling back to :${fallback}`);
+  return fallback;
+}
+
+const PORT = resolvePort(process.env.PORT, DEFAULT_PORT);
 
 let mode: GameMode = 'crash_dual';
 let bankroll = 100000;

--- a/server/test/duel-bet-validation.test.js
+++ b/server/test/duel-bet-validation.test.js
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import WebSocket from 'ws';
 
-const PORT = 19082;
+const PORT = 19083;
 
 function createMessageQueue(ws) {
   const queue = [];
@@ -53,8 +53,9 @@ test('rejects duel bets without a side without charging the wallet', async (t) =
     env: { ...process.env, PORT: String(PORT) },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  t.after(() => {
+  t.after(async () => {
     server.kill('SIGTERM');
+    await once(server, 'exit');
   });
 
   await once(server.stdout, 'data');

--- a/server/test/server-port-fallback.test.js
+++ b/server/test/server-port-fallback.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import WebSocket from 'ws';
+
+const FALLBACK_PORT = 8081;
+
+test('uses fallback port when PORT env var is invalid', async (t) => {
+  const server = spawn('node', ['dist/server.js'], {
+    env: { ...process.env, PORT: 'abc' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  t.after(async () => {
+    server.kill('SIGTERM');
+    await once(server, 'exit');
+  });
+
+  let warningLog = '';
+  server.stderr.on('data', (chunk) => {
+    warningLog += chunk.toString();
+  });
+
+  const [startupChunk] = await once(server.stdout, 'data');
+  const startupLog = startupChunk.toString();
+  assert.ok(
+    startupLog.includes(`:${FALLBACK_PORT}`),
+    `Expected startup log to reference fallback port ${FALLBACK_PORT}, got: ${startupLog}`
+  );
+
+  const ws = new WebSocket(`ws://127.0.0.1:${FALLBACK_PORT}`);
+  t.after(() => {
+    ws.close();
+  });
+
+  await once(ws, 'open');
+  assert.equal(ws.readyState, WebSocket.OPEN);
+  assert.equal(server.exitCode, null);
+
+  if (!warningLog) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  assert.match(
+    warningLog,
+    /Invalid PORT environment value "abc"/,
+    `Expected warning about invalid PORT env var, got: ${warningLog}`
+  );
+});

--- a/server/test/ws-auth.test.js
+++ b/server/test/ws-auth.test.js
@@ -63,8 +63,9 @@ test('allows betting and cashing out on the same authenticated socket', async (t
     env: { ...process.env, PORT: String(PORT) },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  t.after(() => {
+  t.after(async () => {
     server.kill('SIGTERM');
+    await once(server, 'exit');
   });
 
   await once(server.stdout, 'data');


### PR DESCRIPTION
## Summary
- validate the PORT environment variable before starting the websocket server and fall back to the default when parsing fails
- add a regression test that spawns the compiled server with an invalid PORT and verifies it uses the default successfully
- make websocket integration tests wait for spawned servers to exit and avoid port collisions during the suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d142c5b84083208ffad02ded77ece3