### PR TITLE
Implement provably fair crash and duel rounds

### DIFF
--- a/server/src/fair.ts
+++ b/server/src/fair.ts
@@ -1,0 +1,79 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+
+const HMAC_PREFIX_BYTES = 13; // 52 bits -> 13 hex chars
+const TWO_POW_52 = 2 ** 52;
+
+export interface RoundConfig {
+  serverSeed: string;
+  clientSeed: string;
+  nonce: number;
+}
+
+export interface CrashRoundResult {
+  targetA: number;
+  targetB: number;
+  hmacA: string;
+  hmacB: string;
+}
+
+export interface DuelRoundResult {
+  durationExtraMs: number;
+  roll: number;
+  hmacDuration: string;
+  hmacRoll: string;
+}
+
+export function sha256(data: string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+export function hmacHex(key: string, payload: string): string {
+  return createHmac('sha256', key).update(payload).digest('hex');
+}
+
+export function randomSeed(bytes = 32): string {
+  return randomBytes(bytes).toString('hex');
+}
+
+export function uniformFromHmac(hmac: string): number {
+  const slice = hmac.slice(0, HMAC_PREFIX_BYTES);
+  const value = parseInt(slice, 16);
+  return value / TWO_POW_52;
+}
+
+export interface CrashFromHmacOptions {
+  edge?: number;
+  min?: number;
+  max?: number;
+}
+
+export function crashFromHmac(hmac: string, options: CrashFromHmacOptions = {}): number {
+  const edge = typeof options.edge === 'number' ? options.edge : 0.03;
+  const min = typeof options.min === 'number' ? options.min : 1.0;
+  const max = typeof options.max === 'number' ? options.max : Number.POSITIVE_INFINITY;
+
+  const value = parseInt(hmac.slice(0, HMAC_PREFIX_BYTES), 16);
+  const clamped = Math.max(0, Math.min(TWO_POW_52 - 1, value));
+  const inv = TWO_POW_52 / (TWO_POW_52 - clamped);
+  const raw = 1 + (inv - 1) * (1 - edge);
+  const rounded = Math.floor(raw * 100) / 100;
+  return Math.max(min, Math.min(max, rounded));
+}
+
+export function roundCrash(config: RoundConfig): CrashRoundResult {
+  const base = `${config.clientSeed}:${config.nonce}`;
+  const hmacA = hmacHex(config.serverSeed, `${base}:A`);
+  const hmacB = hmacHex(config.serverSeed, `${base}:B`);
+  const targetA = crashFromHmac(hmacA, { edge: 0.04, min: 1.2, max: 250 });
+  const targetB = crashFromHmac(hmacB, { edge: 0.015, min: 1.1, max: 400 });
+  return { targetA, targetB, hmacA, hmacB };
+}
+
+export function roundDuel(config: RoundConfig): DuelRoundResult {
+  const base = `${config.clientSeed}:${config.nonce}`;
+  const durationHmac = hmacHex(config.serverSeed, `${base}:duration`);
+  const rollHmac = hmacHex(config.serverSeed, `${base}:roll`);
+  const durationExtraMs = Math.floor(uniformFromHmac(durationHmac) * 4000);
+  const roll = uniformFromHmac(rollHmac);
+  return { durationExtraMs, roll, hmacDuration: durationHmac, hmacRoll: rollHmac };
+}

--- a/server/src/game_crash_dual.ts
+++ b/server/src/game_crash_dual.ts
@@ -1,24 +1,31 @@
-import { CrashRound, Bet } from './types.js';
+import { CrashRound, Bet, CrashFairInfo } from './types.js';
 import { now } from './utils.js';
 import { smoothMultiplier, jumpyMultiplier } from './math.js';
 import { v4 as uuid } from 'uuid';
 
-export function newCrashRound(): CrashRound {
+export interface CrashRoundInit {
+  targetA: number;
+  targetB: number;
+  fair: CrashFairInfo;
+}
+
+export function newCrashRound(init: CrashRoundInit): CrashRound {
   const start = now();
   return {
     id: uuid(),
     phase: 'betting',
     startedAt: start,
     endsAt: start + 4000,
-    targetA: 1.2 + Math.random() * 9.8,
-    targetB: 1.1 + Math.random() * 14.9,
+    targetA: init.targetA,
+    targetB: init.targetB,
     mA: 1,
     mB: 1,
     betsA: [],
     betsB: [],
     burned: 0,
     payouts: 0,
-    seenBetIds: new Set()
+    seenBetIds: new Set(),
+    fair: { ...init.fair }
   };
 }
 

--- a/server/src/game_duel_ab.ts
+++ b/server/src/game_duel_ab.ts
@@ -1,25 +1,49 @@
-import { DuelRound, Bet, Side } from './types.js';
+import { DuelRound, Bet, Side, DuelFairInfo } from './types.js';
 import { now } from './utils.js';
 import { v4 as uuid } from 'uuid';
 
-export function newDuelRound(): DuelRound {
+const secretRolls = new WeakMap<DuelRound, number>();
+
+export interface DuelRoundInit {
+  fair: DuelFairInfo;
+  runtimeExtraMs: number;
+  roll: number;
+}
+
+export function newDuelRound(init: DuelRoundInit): DuelRound {
   const start = now();
-  return {
+  const round: DuelRound = {
     id: uuid(),
     phase: 'betting',
     startedAt: start,
     endsAt: start + 5000,
     micro: { A: { speed: 0, defense: 0 }, B: { speed: 0, defense: 0 } },
     bets: [],
-    seenBetIds: new Set()
+    seenBetIds: new Set(),
+    runtimeExtraMs: init.runtimeExtraMs,
+    fair: { ...init.fair }
   };
+  secretRolls.set(round, init.roll);
+  return round;
 }
 
-export function resolveDuel(r: DuelRound) {
+export interface DuelResolution {
+  roll: number;
+  pA: number;
+  pB: number;
+}
+
+export function resolveDuel(r: DuelRound): DuelResolution {
+  const roll = secretRolls.get(r);
+  if (roll === undefined) {
+    throw new Error('missing duel fairness roll');
+  }
+  secretRolls.delete(r);
   const wA = 1 + Math.max(-0.8, Math.min(0.8, (r.micro.A.speed - r.micro.B.defense) * 0.05));
   const wB = 1 + Math.max(-0.8, Math.min(0.8, (r.micro.B.speed - r.micro.A.defense) * 0.05));
   const pA = wA / (wA + wB);
-  r.winner = Math.random() < pA ? 'A' : 'B';
+  r.winner = roll < pA ? 'A' : 'B';
+  return { roll, pA, pB: 1 - pA };
 }
 
 export function transitionDuel(r: DuelRound) {
@@ -28,10 +52,13 @@ export function transitionDuel(r: DuelRound) {
     if (r.phase === 'betting') {
       r.phase = 'running';
       r.startedAt = t;
-      r.endsAt = t + 6000 + Math.floor(Math.random()*4000);
+      r.endsAt = t + 6000 + r.runtimeExtraMs;
     } else if (r.phase === 'running') {
       r.phase = 'resolve';
-      resolveDuel(r);
+      const { roll, pA, pB } = resolveDuel(r);
+      r.fair.roll = roll;
+      r.fair.pA = pA;
+      r.fair.pB = pB;
       r.endsAt = t + 1000;
     } else if (r.phase === 'resolve') {
       r.phase = 'intermission';

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -43,6 +43,12 @@ export const PingSchema = z.object({
   t: z.literal('ping')
 });
 
+export const FairSchema = z.object({
+  t: z.literal('fair'),
+  mode: GameModeSchema,
+  nonce: z.number().int().nonnegative().optional()
+});
+
 export const ClientMsgSchema = z.discriminatedUnion('t', [
   AuthSchema,
   SwitchModeSchema,
@@ -50,7 +56,8 @@ export const ClientMsgSchema = z.discriminatedUnion('t', [
   CashoutSchema,
   MicroSchema,
   TopupSchema,
-  PingSchema
+  PingSchema,
+  FairSchema
 ]);
 
 type AssertSide = z.infer<typeof SideSchema> extends Side ? true : never;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -27,6 +27,7 @@ export interface CrashRound {
   burned: number;
   payouts: number;
   seenBetIds: Set<string>;
+  fair: CrashFairInfo;
 }
 
 export interface DuelRound {
@@ -38,6 +39,23 @@ export interface DuelRound {
   bets: Bet[];
   winner?: Side;
   seenBetIds: Set<string>;
+  runtimeExtraMs: number;
+  fair: DuelFairInfo;
+}
+
+export interface BaseFairInfo {
+  serverSeedHash: string;
+  clientSeed: string;
+  nonce: number;
+  serverSeed?: string;
+}
+
+export interface CrashFairInfo extends BaseFairInfo {}
+
+export interface DuelFairInfo extends BaseFairInfo {
+  roll?: number;
+  pA?: number;
+  pB?: number;
 }
 
 export interface RoundStats {
@@ -69,11 +87,35 @@ export type ClientMsg =
   | { t: 'cashout' }
   | { t: 'micro'; what: 'speed' | 'defense'; side: Side; value: number }
   | { t: 'topup'; amount: number }
-  | { t: 'ping' };
+  | { t: 'ping' }
+  | { t: 'fair'; mode: GameMode; nonce?: number };
 
 export type ServerMsg =
   | { t: 'hello'; uid: string; wallet: Wallet; snapshot: Snapshot }
   | { t: 'wallet'; wallet: Wallet }
   | { t: 'snapshot'; snapshot: Snapshot }
   | { t: 'event'; kind: string; payload?: any }
-  | { t: 'error'; message: string };
+  | { t: 'error'; message: string }
+  | FairServerMsg;
+
+export type FairServerMsg =
+  | {
+      t: 'fair';
+      mode: 'crash_dual';
+      nonce: number;
+      roundId: string;
+      clientSeed: string;
+      serverSeedHash: string;
+      serverSeed?: string;
+      crash?: { targetA: number; targetB: number };
+    }
+  | {
+      t: 'fair';
+      mode: 'duel_ab';
+      nonce: number;
+      roundId: string;
+      clientSeed: string;
+      serverSeedHash: string;
+      serverSeed?: string;
+      duel?: { roll?: number; pA?: number; pB?: number; winner?: Side };
+    };

--- a/server/test/bets-idempotency.test.ts
+++ b/server/test/bets-idempotency.test.ts
@@ -82,23 +82,39 @@ function duelBetCount(round: DuelRound | undefined, uid: string) {
   return round.bets.filter((bet) => bet.uid === uid).length;
 }
 
+function simpleCrashRound(nonce: number) {
+  return newCrashRound({
+    targetA: 1.2 + nonce,
+    targetB: 1.5 + nonce,
+    fair: { clientSeed: 'test', serverSeedHash: `hash-${nonce}`, nonce }
+  });
+}
+
+function simpleDuelRound(nonce: number) {
+  return newDuelRound({
+    fair: { clientSeed: 'test', serverSeedHash: `hash-${nonce}`, nonce },
+    runtimeExtraMs: 0,
+    roll: 0.5
+  });
+}
+
 test('game rounds keep seen bet ids per round', () => {
-  const crash = newCrashRound();
+  const crash = simpleCrashRound(0);
   const betCrash: Bet = { id: 'bet-crash', uid: 'u1', amount: 10 };
   assert.equal(addBetCrash(crash, 'A', betCrash), true);
   assert.equal(addBetCrash(crash, 'A', { ...betCrash }), false);
   assert.equal(crash.betsA.length, 1);
 
-  const nextCrash = newCrashRound();
+  const nextCrash = simpleCrashRound(1);
   assert.equal(addBetCrash(nextCrash, 'B', { ...betCrash, side: 'B' }), true);
 
-  const duel = newDuelRound();
+  const duel = simpleDuelRound(0);
   const duelBet: Bet = { id: 'bet-duel', uid: 'u2', amount: 15, side: 'A' };
   assert.equal(addBetDuel(duel, 'A', duelBet), true);
   assert.equal(addBetDuel(duel, 'A', { ...duelBet }), false);
   assert.equal(duel.bets.length, 1);
 
-  const nextDuel = newDuelRound();
+  const nextDuel = simpleDuelRound(1);
   assert.equal(addBetDuel(nextDuel, 'A', { ...duelBet }), true);
 });
 

--- a/server/test/fair.test.ts
+++ b/server/test/fair.test.ts
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { setTimeout as delay } from 'node:timers/promises';
+import WebSocket from 'ws';
+
+import { sha256, hmacHex, roundCrash, roundDuel } from '../src/fair.js';
+import type { ServerMsg } from '../src/types.js';
+
+const PORT = 19121;
+
+interface MessageQueue {
+  waitFor<T extends ServerMsg>(predicate: (msg: ServerMsg) => msg is T, timeout?: number): Promise<T>;
+  pull<T extends ServerMsg>(predicate: (msg: ServerMsg) => msg is T): T | undefined;
+}
+
+function createQueue(ws: WebSocket): MessageQueue {
+  const queue: ServerMsg[] = [];
+  const waiters = new Set<{
+    predicate: (msg: ServerMsg) => boolean;
+    resolve: (msg: ServerMsg) => void;
+    timer: NodeJS.Timeout;
+  }>();
+
+  ws.on('message', (data) => {
+    const msg: ServerMsg = JSON.parse(data.toString());
+    for (const waiter of waiters) {
+      if (waiter.predicate(msg)) {
+        waiters.delete(waiter);
+        clearTimeout(waiter.timer);
+        waiter.resolve(msg);
+        return;
+      }
+    }
+    queue.push(msg);
+  });
+
+  function waitFor<T extends ServerMsg>(predicate: (msg: ServerMsg) => msg is T, timeout = 10000): Promise<T> {
+    for (let i = 0; i < queue.length; i += 1) {
+      const msg = queue[i];
+      if (predicate(msg)) {
+        queue.splice(i, 1);
+        return Promise.resolve(msg);
+      }
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const waiter = {
+        predicate: (msg: ServerMsg) => {
+          if (predicate(msg)) {
+            resolve(msg as T);
+            return true;
+          }
+          return false;
+        },
+        resolve: (msg: ServerMsg) => resolve(msg as T),
+        timer: setTimeout(() => {
+          waiters.delete(waiter);
+          reject(new Error('Timed out waiting for message'));
+        }, timeout)
+      };
+      waiters.add(waiter);
+    });
+  }
+
+  function pull<T extends ServerMsg>(predicate: (msg: ServerMsg) => msg is T): T | undefined {
+    for (let i = 0; i < queue.length; i += 1) {
+      const msg = queue[i];
+      if (predicate(msg)) {
+        queue.splice(i, 1);
+        return msg as T;
+      }
+    }
+    return undefined;
+  }
+
+  return { waitFor, pull };
+}
+
+test('fair helpers are deterministic', () => {
+  const hash = sha256('hello-world');
+  assert.equal(hash, sha256('hello-world'));
+  const hmac = hmacHex('server', 'client:0');
+  assert.equal(hmac, hmacHex('server', 'client:0'));
+
+  const crashOne = roundCrash({ serverSeed: 'seed-1', clientSeed: 'client', nonce: 42 });
+  const crashTwo = roundCrash({ serverSeed: 'seed-1', clientSeed: 'client', nonce: 42 });
+  assert.deepEqual(crashOne, crashTwo);
+  assert.ok(crashOne.targetA >= 1.2);
+  assert.ok(crashOne.targetB >= 1.1);
+
+  const duelOne = roundDuel({ serverSeed: 'seed-1', clientSeed: 'client', nonce: 7 });
+  const duelTwo = roundDuel({ serverSeed: 'seed-1', clientSeed: 'client', nonce: 7 });
+  assert.deepEqual(duelOne, duelTwo);
+  assert.ok(duelOne.roll >= 0 && duelOne.roll < 1);
+});
+
+test('fair websocket api reveals seeds after round resolution', async (t) => {
+  const server = spawn('node', ['dist/server.js'], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  t.after(async () => {
+    server.kill('SIGTERM');
+    await once(server, 'exit');
+  });
+
+  await once(server.stdout, 'data');
+
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  t.after(() => ws.close());
+  await once(ws, 'open');
+  const queue = createQueue(ws);
+
+  ws.send(JSON.stringify({ t: 'auth' }));
+  const hello = await queue.waitFor((msg): msg is Extract<ServerMsg, { t: 'hello' }> => msg.t === 'hello');
+  const crashFair = hello.snapshot.crash?.fair;
+  assert.ok(crashFair);
+
+  ws.send(JSON.stringify({ t: 'fair', mode: 'crash_dual', nonce: crashFair.nonce }));
+  const initialFair = await queue.waitFor(
+    (msg): msg is Extract<ServerMsg, { t: 'fair'; mode: 'crash_dual' }>
+      => msg.t === 'fair' && msg.mode === 'crash_dual'
+  );
+  assert.equal(initialFair.serverSeedHash, crashFair.serverSeedHash);
+  assert.equal(initialFair.roundId, hello.snapshot.crash?.id);
+  assert.equal(initialFair.serverSeed, undefined);
+  assert.equal(initialFair.crash, undefined);
+
+  ws.send(JSON.stringify({ t: 'switch_mode', mode: 'duel_ab' }));
+  const initialDuel = await queue.waitFor(
+    (msg): msg is Extract<ServerMsg, { t: 'snapshot' }>
+      => msg.t === 'snapshot' && msg.snapshot.mode === 'duel_ab'
+  );
+  let resolvedFair: Extract<ServerMsg, { t: 'fair'; mode: 'duel_ab' }> | undefined;
+  let duelRoundId = initialDuel.snapshot.duel?.id;
+  const deadline = Date.now() + 25000;
+  while (!resolvedFair && Date.now() < deadline) {
+    const snapshot = queue.pull(
+      (msg): msg is Extract<ServerMsg, { t: 'snapshot' }>
+        => msg.t === 'snapshot' && msg.snapshot.mode === 'duel_ab'
+    ) ?? await queue.waitFor(
+      (msg): msg is Extract<ServerMsg, { t: 'snapshot' }>
+        => msg.t === 'snapshot' && msg.snapshot.mode === 'duel_ab'
+    );
+    duelRoundId = snapshot.snapshot.duel?.id ?? duelRoundId;
+    if (snapshot.snapshot.duel?.fair.serverSeed && snapshot.snapshot.duel.phase === 'resolve') {
+      ws.send(JSON.stringify({ t: 'fair', mode: 'duel_ab', nonce: snapshot.snapshot.duel.fair.nonce }));
+      resolvedFair = await queue.waitFor(
+        (msg): msg is Extract<ServerMsg, { t: 'fair'; mode: 'duel_ab' }>
+          => msg.t === 'fair' && msg.mode === 'duel_ab' && msg.serverSeed
+      );
+      break;
+    }
+    await delay(100);
+  }
+
+  assert.ok(resolvedFair, 'expected resolved fair message');
+  assert.ok(resolvedFair!.serverSeed);
+  assert.equal(resolvedFair!.roundId, duelRoundId);
+  const duelInfo = resolvedFair!.duel;
+  assert.ok(duelInfo && typeof duelInfo.winner === 'string');
+
+  const recomputed = roundDuel({
+    serverSeed: resolvedFair!.serverSeed!,
+    clientSeed: resolvedFair!.clientSeed,
+    nonce: resolvedFair!.nonce
+  });
+  assert.ok(Math.abs(recomputed.roll - (duelInfo.roll ?? 0)) < 1e-12);
+  assert.equal(sha256(resolvedFair!.serverSeed!), resolvedFair!.serverSeedHash);
+  if (duelInfo.pA !== undefined) {
+    if (duelInfo.winner === 'A') {
+      assert.ok((duelInfo.roll ?? 0) < duelInfo.pA);
+    } else {
+      assert.ok((duelInfo.roll ?? 0) >= (duelInfo.pA ?? 0));
+    }
+  }
+});

--- a/server/test/rtp-sim.test.ts
+++ b/server/test/rtp-sim.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { roundCrash, roundDuel, sha256 } from '../src/fair.js';
+
+test('crash multipliers have stable distribution between sides', () => {
+  const clientSeed = 'rtp-client';
+  const rounds = 2000;
+  let sumA = 0;
+  let sumB = 0;
+  let minA = Number.POSITIVE_INFINITY;
+  let minB = Number.POSITIVE_INFINITY;
+  let maxA = 0;
+  let maxB = 0;
+  for (let i = 0; i < rounds; i += 1) {
+    const serverSeed = sha256(`crash-seed-${i}`);
+    const result = roundCrash({ serverSeed, clientSeed, nonce: i });
+    sumA += result.targetA;
+    sumB += result.targetB;
+    minA = Math.min(minA, result.targetA);
+    minB = Math.min(minB, result.targetB);
+    maxA = Math.max(maxA, result.targetA);
+    maxB = Math.max(maxB, result.targetB);
+  }
+  const avgA = sumA / rounds;
+  const avgB = sumB / rounds;
+  assert.ok(avgA > 1.3 && avgA < 15, `avgA out of range: ${avgA}`);
+  assert.ok(avgB > avgA, `avgB should exceed avgA (avgA=${avgA}, avgB=${avgB})`);
+  assert.ok(minA >= 1.2);
+  assert.ok(minB >= 1.1);
+  assert.ok(maxB >= maxA);
+});
+
+test('duel rolls are uniform and fair at baseline', () => {
+  const clientSeed = 'rtp-client';
+  const rounds = 5000;
+  let winsA = 0;
+  for (let i = 0; i < rounds; i += 1) {
+    const serverSeed = sha256(`duel-seed-${i}`);
+    const duel = roundDuel({ serverSeed, clientSeed, nonce: i });
+    if (duel.roll < 0.5) winsA += 1;
+  }
+  const ratio = winsA / rounds;
+  assert.ok(Math.abs(ratio - 0.5) < 0.03, `ratio out of bounds: ${ratio}`);
+});


### PR DESCRIPTION
## Summary
- add fair.ts utilities for hashing, HMAC, and deterministic crash/duel round generation
- wire the server to manage seeds/nonces, expose fairness history via a new `fair` message, and update schemas/types
- add integration and simulation tests that validate the fairness API and RTP distribution

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d39cb45d9c83208589e5538853add9