### PR TITLE
Remove unnecessary React default imports

### DIFF
--- a/client/src/games/CrashDualCanvas.tsx
+++ b/client/src/games/CrashDualCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 type CrashDualCanvasProps = {
   mA: number;

--- a/client/src/games/DuelABPanel.tsx
+++ b/client/src/games/DuelABPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Badge, type BadgeTone } from '../ui/Badge';
 import { MetricRow } from '../ui/MetricRow';
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles/app.css';


### PR DESCRIPTION
## Summary
- remove unused React default imports from CrashDualCanvas, DuelABPanel, and main entrypoint so the automatic JSX runtime is used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cbabafa08320af217c64a2cefc33