### PR TITLE
Deterministic crash side B multiplier

### DIFF
--- a/server/src/fair.ts
+++ b/server/src/fair.ts
@@ -1,4 +1,5 @@
 import { createHash, createHmac, randomBytes } from 'node:crypto';
+import type { DeterministicSampler } from './types.js';
 
 const HMAC_PREFIX_BYTES = 13; // 52 bits -> 13 hex chars
 const TWO_POW_52 = 2 ** 52;
@@ -67,6 +68,11 @@ export function roundCrash(config: RoundConfig): CrashRoundResult {
   const targetA = crashFromHmac(hmacA, { edge: 0.04, min: 1.2, max: 250 });
   const targetB = crashFromHmac(hmacB, { edge: 0.015, min: 1.1, max: 400 });
   return { targetA, targetB, hmacA, hmacB };
+}
+
+export function crashBSampler(config: RoundConfig): DeterministicSampler {
+  const base = `${config.clientSeed}:${config.nonce}:B`;
+  return (index: number) => uniformFromHmac(hmacHex(config.serverSeed, `${base}:${index}`));
 }
 
 export function roundDuel(config: RoundConfig): DuelRoundResult {

--- a/server/src/math.ts
+++ b/server/src/math.ts
@@ -1,3 +1,5 @@
+import type { DeterministicSampler } from './types.js';
+
 // Плавная (экспо-подобная)
 export function smoothMultiplier(t: number, speed = 1.0) {
   const k = 0.22 * speed;
@@ -5,12 +7,12 @@ export function smoothMultiplier(t: number, speed = 1.0) {
 }
 
 // Скачущая, с шагами и джиттером
-export function jumpyMultiplier(t: number) {
-  const step = Math.floor(t * 4); // 4 шага/сек
+export function jumpyMultiplier(stepInput: number, sampler: DeterministicSampler) {
+  const step = Math.max(0, Math.floor(stepInput)); // 4 шага/сек
   let m = 1.0;
   for (let i = 0; i < step; i++) {
-    const base = 1 + Math.random() * 0.12;     // 0–12% скачок
-    const jitter = (Math.random() - 0.5) * 0.03; // ±3% джиттер
+    const base = 1 + sampler(i * 2) * 0.12; // 0–12% скачок
+    const jitter = (sampler(i * 2 + 1) - 0.5) * 0.03; // ±3% джиттер
     m *= base + jitter;
   }
   return Math.max(1, m);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -4,6 +4,8 @@ export type Side = 'A' | 'B';
 export interface ClientAuth { uid: string; }
 export type Amount = bigint;
 
+export type DeterministicSampler = (index: number) => number;
+
 export interface Wallet {
   balance: Amount;
 }
@@ -32,6 +34,7 @@ export interface CrashRound {
   payouts: Amount;
   seenBetIds: Set<string>;
   fair: CrashFairInfo;
+  streamB: CrashRoundStream;
 }
 
 export interface DuelRound {
@@ -54,7 +57,20 @@ export interface BaseFairInfo {
   serverSeed?: string;
 }
 
-export type CrashFairInfo = BaseFairInfo;
+export interface CrashFairStreamInfo {
+  steps: number;
+  valuesUsed: number;
+}
+
+export interface CrashFairInfo extends BaseFairInfo {
+  bStream: CrashFairStreamInfo;
+}
+
+export interface CrashRoundStream {
+  sampler: DeterministicSampler;
+  steps: number;
+  valuesUsed: number;
+}
 
 export interface DuelFairInfo extends BaseFairInfo {
   roll?: number;
@@ -77,7 +93,7 @@ export interface BetSnapshot extends Omit<Bet, 'amount'> {
   amount: number;
 }
 
-export interface CrashRoundSnapshot extends Omit<CrashRound, 'betsA' | 'betsB' | 'burned' | 'payouts' | 'seenBetIds'> {
+export interface CrashRoundSnapshot extends Omit<CrashRound, 'betsA' | 'betsB' | 'burned' | 'payouts' | 'seenBetIds' | 'streamB'> {
   betsA: BetSnapshot[];
   betsB: BetSnapshot[];
   burned: number;
@@ -130,7 +146,7 @@ export type FairServerMsg =
       clientSeed: string;
       serverSeedHash: string;
       serverSeed?: string;
-      crash?: { targetA: number; targetB: number };
+      crash?: { targetA: number; targetB: number; bStream: CrashFairStreamInfo };
     }
   | {
       t: 'fair';

--- a/server/test/bets-idempotency.test.ts
+++ b/server/test/bets-idempotency.test.ts
@@ -32,7 +32,12 @@ type Queue = {
 };
 
 function makeFair(nonce: number): CrashFairInfo {
-  return { clientSeed: 'test-client', serverSeedHash: `hash-${nonce}`, nonce };
+  return {
+    clientSeed: 'test-client',
+    serverSeedHash: `hash-${nonce}`,
+    nonce,
+    bStream: { steps: 0, valuesUsed: 0 }
+  };
 }
 
 function makeDuelFair(nonce: number): DuelFairInfo {
@@ -82,7 +87,12 @@ function createMessageQueue(ws: WebSocket): Queue {
 }
 
 test('crash and duel rounds record seen bet ids', () => {
-  const crashRound = newCrashRound({ targetA: 1.5, targetB: 1.7, fair: makeFair(1) });
+  const crashRound = newCrashRound({
+    targetA: 1.5,
+    targetB: 1.7,
+    fair: makeFair(1),
+    streamB: { sampler: () => 0 }
+  });
   const bet: Bet = { id: 'crash-1', uid: 'player-1', amount: 50n };
   assert.equal(addBetCrash(crashRound, 'A', bet), true);
   assert.equal(addBetCrash(crashRound, 'A', { ...bet }), false);

--- a/server/test/fair.test.ts
+++ b/server/test/fair.test.ts
@@ -1,7 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { roundCrash, sha256 } from '../src/fair.js';
+import { roundCrash, sha256, crashBSampler, type RoundConfig } from '../src/fair.js';
+import { newCrashRound, tickCrash } from '../src/game_crash_dual.js';
+import { multiplyAmount } from '../src/money.js';
+import type { CrashFairInfo } from '../src/types.js';
 
 test('roundCrash is deterministic for identical inputs', () => {
   const baseConfig = { serverSeed: 'determinism-seed', clientSeed: 'client-123', nonce: 42 };
@@ -25,4 +28,59 @@ test('roundCrash is deterministic for identical inputs', () => {
 
   assert.ok(first.targetA >= 1.2, 'side A minimum multiplier should be respected');
   assert.ok(first.targetB >= 1.1, 'side B minimum multiplier should be respected');
+});
+
+function simulateSideB(config: RoundConfig, steps: number) {
+  const { targetA, targetB } = roundCrash(config);
+  const sampler = crashBSampler(config);
+  const fair: CrashFairInfo = {
+    serverSeedHash: sha256(config.serverSeed),
+    clientSeed: config.clientSeed,
+    nonce: config.nonce,
+    bStream: { steps: 0, valuesUsed: 0 }
+  };
+  const round = newCrashRound({ targetA, targetB, fair, streamB: { sampler } });
+  round.phase = 'running';
+  const runningStart = 1_000_000;
+  round.startedAt = runningStart;
+  round.endsAt = runningStart + 25000;
+
+  const originalNow = Date.now;
+  const multipliers: number[] = [];
+  try {
+    for (let i = 0; i < steps; i += 1) {
+      const ts = runningStart + 4000 + (i + 1) * 250;
+      Date.now = () => ts;
+      tickCrash(round);
+      multipliers.push(round.mB);
+      if (round.phase !== 'running') {
+        break;
+      }
+    }
+  } finally {
+    Date.now = originalNow;
+  }
+
+  return { multipliers, bStream: { ...round.fair.bStream } };
+}
+
+test('side B path and cashout stay deterministic for identical seeds', () => {
+  const config: RoundConfig = { serverSeed: 'determinism-side-b', clientSeed: 'client-abc', nonce: 7 };
+  const steps = 8;
+  const first = simulateSideB(config, steps);
+  const second = simulateSideB(config, steps);
+
+  assert.deepEqual(second.multipliers, first.multipliers, 'trajectory should match when seeds match');
+  assert.deepEqual(second.bStream, first.bStream, 'stream info should match when seeds match');
+  assert.equal(first.multipliers.length, first.bStream.steps, 'recorded multipliers should match steps');
+  assert.equal(second.multipliers.length, second.bStream.steps, 'recorded multipliers should match steps');
+  assert.equal(first.bStream.valuesUsed, first.bStream.steps * 2, 'stream should record uniform draws used');
+
+  const cashoutStep = 5; // steps are 1-indexed in multipliers array
+  const amount = 275n;
+  const firstMultiplier = first.multipliers[Math.min(cashoutStep, first.multipliers.length) - 1];
+  const secondMultiplier = second.multipliers[Math.min(cashoutStep, second.multipliers.length) - 1];
+  const expectedPayout = multiplyAmount(amount, firstMultiplier);
+  const repeatedPayout = multiplyAmount(amount, secondMultiplier);
+  assert.equal(repeatedPayout, expectedPayout, 'cashout payout should be reproducible');
 });


### PR DESCRIPTION
## Summary
* replace the jumpy crash multiplier with an HMAC-derived deterministic sampler and plumb the generator into crash rounds
* extend crash fairness metadata/history to expose B-side stream usage in snapshots and fair responses
* update crash tests to provide stream information and assert deterministic B-side trajectories and payouts

## Testing
* npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d401a914832092d903388e2481a3