### PR TITLE
Embed static page structure and styles

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,25 +3,1783 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Clash Dual is a realtime crash and duel playground for experimenting with casino-style mechanics."
-    />
+    <meta name="description" content="Clash Dual is a realtime crash and duel playground for experimenting with casino-style mechanics." />
     <meta name="theme-color" content="#131937" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
-    <title>Clash Dual · Realtime Crash &amp; Duel Playground</title>
-    <script type="module">
-      const commit = import.meta.env.VITE_COMMIT || 'local';
-      document.title = `build ${commit} Clash Dual · Realtime Crash & Duel Playground`;
-    </script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <title>Clash Dual · Realtime Crash & Duel Playground</title>
+    <style>
+:root {
+  --font-sans: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --gap-lg: 24px;
+  --gap-md: 16px;
+  --gap-sm: 10px;
+  --header-height: 92px;
+  color-scheme: dark;
+  --color-page: #050816;
+  --color-page-overlay: radial-gradient(circle at 12% 10%, rgba(124, 109, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(77, 208, 255, 0.24), transparent 54%),
+    radial-gradient(circle at 18% 78%, rgba(111, 86, 255, 0.22), transparent 52%),
+    linear-gradient(160deg, rgba(5, 8, 22, 0.8), rgba(3, 6, 18, 0.94));
+  --color-body: #e7edff;
+  --color-muted: #8d9bd3;
+  --color-faint: rgba(141, 155, 211, 0.35);
+  --color-primary: #7c6dff;
+  --color-primary-soft: rgba(124, 109, 255, 0.16);
+  --color-secondary: #4dd0ff;
+  --color-secondary-soft: rgba(77, 208, 255, 0.18);
+  --color-success: #5ee1b0;
+  --color-success-soft: rgba(94, 225, 176, 0.2);
+  --color-warning: #ffc860;
+  --color-warning-soft: rgba(255, 200, 96, 0.2);
+  --color-danger: #ff7da0;
+  --color-danger-soft: rgba(255, 125, 160, 0.2);
+  --color-info: #88a3ff;
+  --color-info-soft: rgba(136, 163, 255, 0.2);
+  --color-surface: linear-gradient(145deg, rgba(20, 26, 48, 0.85), rgba(12, 18, 36, 0.95));
+  --color-surface-strong: linear-gradient(155deg, rgba(27, 34, 66, 0.92), rgba(10, 15, 30, 0.94));
+  --color-border: rgba(112, 142, 255, 0.18);
+  --color-border-strong: rgba(108, 128, 190, 0.32);
+  --shadow-soft: 0 18px 45px rgba(6, 10, 28, 0.45), 0 0 0 1px rgba(134, 155, 255, 0.08) inset;
+  --shadow-strong: 0 28px 70px rgba(5, 8, 20, 0.65), 0 0 0 1px rgba(150, 168, 255, 0.12) inset;
+  --color-heading: #f6f8ff;
+  --color-header: linear-gradient(160deg, rgba(13, 19, 40, 0.92), rgba(8, 12, 27, 0.92));
+  --color-header-border: rgba(120, 146, 255, 0.22);
+  --shadow-header: 0 24px 60px rgba(3, 5, 16, 0.6);
+  --color-logo: linear-gradient(135deg, rgba(124, 109, 255, 0.85), rgba(77, 208, 255, 0.7));
+  --color-logo-ink: #0b0f22;
+  --shadow-logo: 0 20px 36px rgba(60, 90, 210, 0.4);
+  --color-summary-border: rgba(122, 144, 255, 0.28);
+  --shadow-summary: 0 18px 40px rgba(6, 10, 26, 0.35);
+  --shadow-badge: 0 6px 18px rgba(6, 10, 24, 0.25);
+  --shadow-segmented: 0 12px 28px rgba(6, 10, 24, 0.4) inset;
+  --badge-default-bg: rgba(140, 150, 255, 0.1);
+  --badge-primary-bg: linear-gradient(135deg, rgba(124, 109, 255, 0.2), rgba(146, 124, 255, 0.35));
+  --badge-primary-border: rgba(124, 109, 255, 0.55);
+  --badge-primary-text: #efeaff;
+  --badge-secondary-bg: linear-gradient(135deg, rgba(77, 208, 255, 0.22), rgba(59, 164, 255, 0.35));
+  --badge-secondary-border: rgba(77, 208, 255, 0.6);
+  --badge-secondary-text: #ddf7ff;
+  --badge-muted-bg: linear-gradient(135deg, rgba(141, 155, 211, 0.14), rgba(109, 121, 188, 0.18));
+  --badge-muted-border: rgba(141, 155, 211, 0.4);
+  --badge-muted-text: var(--color-body);
+  --badge-info-bg: var(--color-info-soft);
+  --badge-info-border: rgba(136, 163, 255, 0.45);
+  --badge-info-text: #dbe3ff;
+  --badge-success-bg: var(--color-success-soft);
+  --badge-success-border: rgba(94, 225, 176, 0.45);
+  --badge-success-text: #d3fce9;
+  --badge-warning-bg: var(--color-warning-soft);
+  --badge-warning-border: rgba(255, 200, 96, 0.45);
+  --badge-warning-text: #ffe6bb;
+  --badge-danger-bg: var(--color-danger-soft);
+  --badge-danger-border: rgba(255, 125, 160, 0.5);
+  --badge-danger-text: #ffe1eb;
+  --button-text: #f5f7ff;
+  --button-primary-bg: linear-gradient(135deg, rgba(124, 109, 255, 0.9), rgba(151, 131, 255, 0.85));
+  --button-primary-shadow: 0 16px 32px rgba(86, 74, 196, 0.45);
+  --button-secondary-bg: linear-gradient(135deg, rgba(74, 196, 255, 0.9), rgba(60, 162, 255, 0.85));
+  --button-secondary-shadow: 0 16px 32px rgba(39, 126, 205, 0.45);
+  --button-muted-bg: linear-gradient(135deg, rgba(30, 42, 74, 0.92), rgba(20, 30, 60, 0.9));
+  --button-muted-text: var(--color-muted);
+  --button-muted-shadow: 0 10px 24px rgba(8, 12, 30, 0.45);
+  --segmented-active-bg: linear-gradient(135deg, rgba(124, 109, 255, 0.95), rgba(146, 124, 255, 0.85));
+  --segmented-active-color: #f9f6ff;
+  --segmented-active-shadow: 0 12px 28px rgba(86, 74, 196, 0.45);
+  --color-input-bg: linear-gradient(145deg, rgba(12, 18, 36, 0.95), rgba(8, 12, 24, 0.95));
+  --color-input-border: rgba(133, 156, 255, 0.26);
+  --color-input-border-focus: rgba(124, 109, 255, 0.75);
+  --color-input-ring: rgba(124, 109, 255, 0.35);
+  --color-panel: rgba(16, 24, 48, 0.72);
+  --color-panel-alt: rgba(14, 20, 40, 0.55);
+  --color-panel-border: rgba(122, 146, 255, 0.28);
+  --color-panel-border-strong: rgba(120, 138, 220, 0.18);
+  --shadow-panel: 0 18px 32px rgba(6, 10, 26, 0.38);
+  --shadow-panel-strong: 0 18px 30px rgba(6, 10, 26, 0.4);
+  --shadow-balance: 0 12px 32px rgba(42, 58, 140, 0.45);
+  --color-scrollbar-thumb: rgba(124, 109, 255, 0.35);
+  --color-scrollbar-track: rgba(16, 20, 42, 0.65);
+  --color-chip-border: rgba(124, 138, 220, 0.28);
+  --color-side-a-border: rgba(126, 171, 255, 0.48);
+  --color-side-b-border: rgba(255, 158, 206, 0.45);
+  --color-canvas: rgba(5, 8, 22, 0.85);
+  --color-canvas-border: rgba(124, 138, 220, 0.25);
+  --color-footer: rgba(8, 12, 27, 0.92);
+  --color-footer-border: rgba(120, 146, 255, 0.22);
+  --shadow-footer: 0 -22px 48px rgba(3, 5, 16, 0.5);
+  --color-event: rgba(14, 22, 42, 0.9);
+  --color-event-border: rgba(110, 132, 214, 0.22);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--color-page);
+  color: var(--color-body);
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  justify-content: center;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: var(--color-page-overlay);
+  z-index: -1;
+  opacity: 0.95;
+}
+
+#root {
+  width: 100%;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(14px);
+}
+
+.app-header {
+  display: grid;
+  grid-template-columns: minmax(0, 420px) minmax(0, 340px) minmax(0, 260px);
+  gap: clamp(18px, 3vw, 32px);
+  padding: clamp(28px, 5vw, 48px);
+  background: var(--color-header);
+  border-bottom: 1px solid var(--color-header-border);
+  box-shadow: var(--shadow-header);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(18px);
+}
+
+.app-header__title,
+.app-header__badges,
+.app-header__controls {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(20px, 2.3vw, 28px);
+}
+
+.app-header__title {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--gap-md);
+  overflow: hidden;
+}
+
+.app-header__title::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% 20%, var(--color-secondary-soft), transparent 55%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.app-header__logo {
+  width: clamp(58px, 6vw, 72px);
+  height: clamp(58px, 6vw, 72px);
+  border-radius: 22px;
+  background: var(--color-logo);
+  display: grid;
+  place-items: center;
+  font-size: clamp(24px, 3vw, 30px);
+  color: var(--color-logo-ink);
+  box-shadow: var(--shadow-logo);
+}
+
+.app-header__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app-header__eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.app-header__title h1 {
+  margin: 0;
+  font-size: clamp(26px, 3.6vw, 34px);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--color-heading);
+}
+
+.app-header__lead {
+  margin: 0;
+  font-size: clamp(14px, 1.6vw, 16px);
+  line-height: 1.6;
+  color: var(--color-muted);
+  max-width: 42ch;
+}
+
+.app-header__badges {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.app-header__badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+}
+
+.app-header__hint {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-muted);
+}
+
+.app-header__controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  align-items: stretch;
+}
+
+.app-header__controls-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.app-header__controls-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.app-header__controls-hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-faint);
+}
+
+.app-header__controls .segmented {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.app-header__controls .segmented button {
+  flex: 1;
+}
+
+.app-main {
+  --layout-max-width: 1640px;
+  --layout-gutter: clamp(28px, 5vw, 48px);
+  --layout-column-gap: clamp(24px, 4vw, 36px);
+  flex: 1;
+  width: 100%;
+  padding: clamp(40px, 6vw, 80px) 0 clamp(64px, 8vw, 108px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(32px, 5vw, 48px);
+}
+
+.app-main__intro {
+  width: min(100%, var(--layout-max-width));
+  margin: 0 auto;
+  padding: clamp(24px, 3vw, 36px);
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
+  gap: clamp(18px, 3vw, 32px);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.app-main__intro-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.app-main__intro-copy h2 {
+  margin: 0;
+  font-size: clamp(22px, 3vw, 28px);
+  font-weight: 700;
+  color: var(--color-heading);
+  letter-spacing: 0.02em;
+}
+
+.app-main__intro-copy p {
+  margin: 0;
+  font-size: clamp(14px, 1.4vw, 16px);
+  line-height: 1.6;
+  color: var(--color-muted);
+}
+
+.app-main__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: clamp(12px, 2.5vw, 18px);
+}
+
+.app-main__summary-item {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-summary-border);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: var(--shadow-summary);
+}
+
+.app-main__summary-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+}
+
+.app-main__summary-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.layout {
+  width: min(100%, var(--layout-max-width));
+  margin: 0 auto;
+  padding: 0 var(--layout-gutter) 18px;
+  display: grid;
+  grid-template-columns:
+    minmax(260px, clamp(300px, 22vw, 360px))
+    minmax(520px, 1fr)
+    minmax(260px, clamp(300px, 22vw, 360px));
+  gap: var(--layout-column-gap);
+  align-items: start;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+}
+
+.layout::-webkit-scrollbar {
+  height: 8px;
+}
+
+.layout::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar-thumb);
+  border-radius: 999px;
+}
+
+.layout::-webkit-scrollbar-track {
+  background: var(--color-scrollbar-track);
+  border-radius: 999px;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-lg);
+  min-width: 0;
+}
+
+.column-left {
+  grid-column: 1;
+}
+
+.column-center {
+  grid-column: 2;
+  max-width: 760px;
+}
+
+.column-right {
+  grid-column: 3;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--gap-md);
+  margin-bottom: 4px;
+}
+
+.card-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.card-subtitle {
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.card-actions {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: center;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.text-primary {
+  color: var(--color-primary);
+}
+
+.text-secondary {
+  color: var(--color-secondary);
+}
+
+.text-muted {
+  color: var(--color-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  background: var(--badge-default-bg);
+  color: var(--color-body);
+  box-shadow: var(--shadow-badge);
+}
+
+.badge-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.badge--primary {
+  background: var(--badge-primary-bg);
+  border-color: var(--badge-primary-border);
+  color: var(--badge-primary-text);
+}
+
+.badge--secondary {
+  background: var(--badge-secondary-bg);
+  border-color: var(--badge-secondary-border);
+  color: var(--badge-secondary-text);
+}
+
+.badge--muted {
+  background: var(--badge-muted-bg);
+  border-color: var(--badge-muted-border);
+  color: var(--badge-muted-text);
+}
+
+.badge--info {
+  background: var(--badge-info-bg);
+  border-color: var(--badge-info-border);
+  color: var(--badge-info-text);
+}
+
+.badge--success {
+  background: var(--badge-success-bg);
+  border-color: var(--badge-success-border);
+  color: var(--badge-success-text);
+}
+
+.badge--warning {
+  background: var(--badge-warning-bg);
+  border-color: var(--badge-warning-border);
+  color: var(--badge-warning-text);
+}
+
+.badge--danger {
+  background: var(--badge-danger-bg);
+  border-color: var(--badge-danger-border);
+  color: var(--badge-danger-text);
+}
+
+.metric-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--gap-sm);
+  align-items: flex-start;
+}
+
+.metric-row--start {
+  align-items: center;
+}
+
+.metric-label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+}
+
+.metric-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-heading);
+  text-align: right;
+}
+
+.metric-hint {
+  font-size: 12px;
+  color: var(--color-faint);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.button {
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.15s ease, filter 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--button-text);
+}
+
+.button--compact {
+  padding: 6px 12px;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+
+.button--primary {
+  background: var(--button-primary-bg);
+  box-shadow: var(--button-primary-shadow);
+}
+
+.button--secondary {
+  background: var(--button-secondary-bg);
+  box-shadow: var(--button-secondary-shadow);
+}
+
+.button--muted {
+  background: var(--button-muted-bg);
+  color: var(--button-muted-text);
+  box-shadow: var(--button-muted-shadow);
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  filter: saturate(0.75) brightness(0.85);
+  opacity: 0.7;
+}
+
+.segmented {
+  display: inline-flex;
+  padding: 6px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-segmented);
+  gap: 6px;
+}
+
+.segmented button {
+  border-radius: calc(var(--radius-md) - 4px);
+  background: transparent;
+  border: 0;
+  padding: 10px 16px;
+  color: var(--color-muted);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.segmented button[data-active='true'] {
+  background: var(--segmented-active-bg);
+  color: var(--segmented-active-color);
+  box-shadow: var(--segmented-active-shadow);
+}
+
+.segmented--spread {
+  width: 100%;
+}
+
+.segmented--spread button {
+  flex: 1;
+}
+
+input[type='number'],
+input[type='text'],
+input[type='search'],
+input[type='email'] {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
+  color: var(--color-heading);
+  padding: 10px 12px;
+  font-size: 14px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--color-input-border-focus);
+  box-shadow: 0 0 0 2px var(--color-input-ring);
+}
+
+input:disabled {
+  opacity: 0.6;
+}
+
+input[type='range'] {
+  width: 100%;
+  accent-color: var(--color-secondary);
+  cursor: pointer;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.wallet-balance {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.wallet-balance__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.wallet-balance__value {
+  font-size: clamp(28px, 3.5vw, 38px);
+  font-weight: 700;
+  color: var(--color-heading);
+  text-shadow: var(--shadow-balance);
+}
+
+.wallet-balance__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+}
+
+.wallet-topups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+}
+
+.wallet-topups .button {
+  flex: 1 0 100px;
+  min-width: 96px;
+}
+
+.wallet-topups__hint {
+  font-size: 12px;
+}
+
+.wallet-targets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  background: var(--color-panel);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  box-shadow: var(--shadow-panel);
+}
+
+.wallet-targets__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.wallet-targets__inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--gap-sm);
+}
+
+.wallet-targets__input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.wallet-targets__input label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.wallet-targets__foot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.wallet-targets__round {
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.wallet-targets__delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wallet-targets__delta strong {
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.wallet-targets__divider {
+  color: var(--color-faint);
+}
+
+.wallet-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--gap-sm);
+}
+
+.wallet-metrics .metric-row {
+  background: var(--color-panel-alt);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  border: 1px solid var(--color-panel-border-strong);
+}
+
+.wallet-metrics .metric-value {
+  text-align: left;
+}
+
+.bet-stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  justify-content: space-between;
+}
+
+.bet-stepper__value {
+  flex: 1;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.bet-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+}
+
+.bet-presets .button {
+  flex: 1 0 100px;
+  min-width: 96px;
+}
+
+.bet-presets .button[data-active='true'] {
+  background: var(--segmented-active-bg);
+  color: var(--segmented-active-color);
+  box-shadow: var(--segmented-active-shadow);
+}
+
+.bet-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bet-slider__scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.bet-side-overview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bet-side-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-chip-border);
+  background: var(--color-panel);
+  box-shadow: var(--shadow-panel-strong);
+  min-width: 160px;
+}
+
+.bet-side-chip[data-side='A'] {
+  border-color: var(--color-side-a-border);
+}
+
+.bet-side-chip[data-side='B'] {
+  border-color: var(--color-side-b-border);
+}
+
+.bet-side-chip__label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.bet-side-chip__value {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.bet-side-chip__plan {
+  font-size: 12px;
+  color: var(--color-secondary);
+}
+
+.bet-side-actions {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: center;
+}
+
+.bet-side-actions .button[data-active='true'] {
+  background: var(--segmented-active-bg);
+  color: var(--segmented-active-color);
+  box-shadow: var(--segmented-active-shadow);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+}
+
+.arena-body {
+  gap: var(--gap-lg);
+}
+
+.arena-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr);
+  gap: var(--gap-lg);
+}
+
+.arena-stage {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 360px;
+  box-shadow: var(--shadow-strong);
+  padding: 20px;
+}
+
+.arena-stage canvas {
+  width: 100%;
+  height: auto;
+  border-radius: calc(var(--radius-lg) - 6px);
+  border: 1px solid var(--color-canvas-border);
+  background: var(--color-canvas);
+}
+
+.arena-empty {
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.arena-sidebar {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-soft);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.arena-sidebar-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.arena-parameters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.micro-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gap-md);
+}
+
+.micro-side {
+  background: var(--color-panel);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-panel-border);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  box-shadow: var(--shadow-panel-strong);
+}
+
+.micro-side-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.micro-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.micro-controls {
+  display: flex;
+  gap: var(--gap-sm);
+}
+
+.duel-arena {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.duel-arena-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--gap-md);
+}
+
+.duel-arena-side {
+  background: var(--color-panel-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-panel-border-strong);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.duel-arena-status {
+  display: flex;
+  gap: var(--gap-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.event-item {
+  background: var(--color-event);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-event-border);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.event-time {
+  font-size: 11px;
+  color: var(--color-faint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.event-text {
+  font-size: 13px;
+  color: var(--color-heading);
+}
+
+.app-footer {
+  padding: clamp(20px, 4vw, 32px) clamp(28px, 6vw, 64px) clamp(32px, 6vw, 48px);
+  background: var(--color-footer);
+  border-top: 1px solid var(--color-footer-border);
+  box-shadow: var(--shadow-footer);
+}
+
+.app-footer__inner {
+  max-width: min(1680px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(10px, 2.5vw, 18px);
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+
+.app-footer__brand {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+}
+
+.app-footer__note {
+  flex: 1 1 240px;
+  font-size: 13px;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--color-muted);
+}
+
+.app-footer__build {
+  color: var(--color-secondary);
+  font-weight: 600;
+}
+
+@media (max-width: 1400px) {
+  .app-header {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 0.9fr);
+    padding-inline: clamp(32px, 6vw, 48px);
+  }
+
+  .app-main__intro {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .layout {
+    grid-template-columns:
+      minmax(240px, clamp(280px, 28vw, 320px))
+      minmax(460px, 1fr)
+      minmax(240px, clamp(280px, 28vw, 320px));
+    gap: clamp(22px, 4vw, 32px);
+  }
+}
+
+@media (max-width: 1180px) {
+  .app-header {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    row-gap: clamp(16px, 3vw, 24px);
+  }
+
+  .app-header__controls {
+    grid-column: span 2;
+  }
+
+  .app-header__controls .segmented {
+    justify-content: flex-start;
+  }
+
+  .layout {
+    --layout-max: 1540px;
+    --layout-hpad: clamp(24px, 7vw, 48px);
+    --column-side: clamp(260px, 28vw, 320px);
+    --column-center: clamp(480px, 52vw, 660px);
+    grid-template-columns: minmax(0, var(--column-side)) minmax(0, 1fr)
+      minmax(0, var(--column-side));
+  }
+
+  .column-right {
+    grid-column: 3;
+  }
+}
+
+@media (max-width: 1040px) {
+  .layout {
+
+    --layout-max: 100%;
+    --layout-hpad: clamp(22px, 7vw, 38px);
+    --column-side: clamp(220px, 34vw, 280px);
+    --column-center: clamp(360px, 52vw, 520px);
+    grid-template-columns: minmax(0, var(--column-side)) minmax(0, 1fr)
+      minmax(0, var(--column-side));
+    gap: var(--gap-md);
+  }
+
+  .column-left {
+    grid-column: 1;
+  }
+
+  .column-center {
+    grid-column: 2;
+    max-width: none;
+  }
+
+  .app-header {
+    grid-template-columns: minmax(0, 1fr);
+    position: static;
+    padding-inline: clamp(22px, 6vw, 36px);
+    row-gap: clamp(16px, 3vw, 24px);
+  }
+
+  .column-right {
+    grid-column: 1 / -1;
+  }
+
+  .app-main__intro {
+    margin-inline: clamp(22px, 7vw, 36px);
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .arena-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .micro-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-footer__inner {
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+@media (max-width: 780px) {
+  .layout {
+
+    --layout-hpad: clamp(18px, 8vw, 28px);
+    --column-side: clamp(240px, 76vw, 320px);
+    --column-center: clamp(360px, 88vw, 520px);
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--gap-md);
+  }
+
+  .column-left,
+  .column-center,
+  .column-right {
+    grid-column: 1;
+  }
+
+  .app-main__intro {
+    margin-inline: clamp(18px, 8vw, 28px);
+  }
+}
+
+@media (max-width: 640px) {
+  .app-main {
+    padding-block: 28px 40px;
+  }
+
+  .app-main__intro {
+    padding: 20px;
+    gap: var(--gap-md);
+  }
+
+  .app-main__summary {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .app-header {
+    grid-template-columns: minmax(0, 1fr);
+    padding-inline: 18px;
+  }
+
+  .app-header__title,
+  .app-header__badges,
+  .app-header__controls {
+    padding: 20px;
+  }
+
+  .app-header__logo {
+    width: 56px;
+    height: 56px;
+  }
+
+  .app-header__title h1 {
+    font-size: 22px;
+  }
+
+  .app-header__lead {
+    font-size: 13px;
+  }
+
+  .badge {
+    font-size: 11px;
+  }
+
+  .app-footer__inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    text-align: left;
+  }
+
+  .app-footer__note {
+    font-size: 12px;
+  }
+}
+
+
+      .build-indicator {
+        position: fixed;
+        bottom: 24px;
+        right: 24px;
+        z-index: 1000;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        border-radius: 999px;
+        background: var(--color-surface-strong);
+        border: 1px solid var(--color-border-strong);
+        box-shadow: 0 18px 40px rgba(6, 10, 26, 0.35);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-muted);
+      }
+
+      .build-indicator__commit {
+        color: var(--color-secondary);
+        font-weight: 600;
+      }
+
+    </style>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="app-header__title">
+          <div class="app-header__logo" aria-hidden="true">✦</div>
+          <div class="app-header__copy">
+            <span class="app-header__eyebrow">Realtime casino sandbox</span>
+            <h1>Clash Dual</h1>
+            <p class="app-header__lead">Balance crash flights and duel skirmishes from one cinematic control room.</p>
+          </div>
+        </div>
+        <div class="app-header__badges">
+          <div class="app-header__badge-row">
+            <span class="badge badge--success">Connection · Live</span>
+            <span class="badge badge--primary">Mode · Crash Dual</span>
+            <span class="badge badge--warning">Phase · Betting</span>
+            <span class="badge badge--muted">Rounds · 128</span>
+          </div>
+          <p class="app-header__hint">Monitor live telemetry, tweak multipliers, and launch your bets the moment the skies align.</p>
+        </div>
+        <div class="app-header__controls">
+          <div class="app-header__controls-group">
+            <span class="app-header__controls-label">Game mode</span>
+            <div class="segmented segmented--spread" role="group" aria-label="Select game mode">
+              <button class="button button--muted" type="button" data-active="true">Crash</button>
+              <button class="button button--muted" type="button" data-active="false" disabled>A/B Duel</button>
+            </div>
+            <p class="app-header__controls-hint">Switch modes while connected to explore both arenas.</p>
+          </div>
+        </div>
+      </header>
+
+      <main class="app-main">
+        <section class="app-main__intro">
+          <div class="app-main__intro-copy">
+            <h2>Command center</h2>
+            <p>Choose your side, track the pools, and react instantly to shifting phases.</p>
+          </div>
+          <div class="app-main__summary">
+            <div class="app-main__summary-item">
+              <span class="app-main__summary-label">Wallet</span>
+              <span class="app-main__summary-value">$25,000.00</span>
+            </div>
+            <div class="app-main__summary-item">
+              <span class="app-main__summary-label">Game mode</span>
+              <span class="app-main__summary-value">Crash Dual</span>
+            </div>
+            <div class="app-main__summary-item">
+              <span class="app-main__summary-label">Risk profile</span>
+              <span class="app-main__summary-value">Balanced</span>
+            </div>
+            <div class="app-main__summary-item">
+              <span class="app-main__summary-label">Operator edge</span>
+              <span class="app-main__summary-value">4.00%</span>
+            </div>
+            <div class="app-main__summary-item">
+              <span class="app-main__summary-label">Rounds played</span>
+              <span class="app-main__summary-value">128</span>
+            </div>
+          </div>
+        </section>
+
+        <div class="layout">
+          <div class="column column-left">
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Wallet &amp; Mode</div>
+                  <div class="card-subtitle">Session overview</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <div class="wallet-balance">
+                  <span class="wallet-balance__label">Balance</span>
+                  <div class="wallet-balance__value">$25,000.00</div>
+                  <div class="wallet-balance__tags">
+                    <span class="badge badge--success">Connection · Live</span>
+                    <span class="badge badge--secondary">Risk · Balanced</span>
+                  </div>
+                </div>
+
+                <div class="wallet-topups">
+                  <button class="button button--primary" type="button">+ $500</button>
+                  <button class="button button--primary" type="button">+ $1,000</button>
+                  <button class="button button--primary" type="button">+ $2,500</button>
+                  <button class="button button--primary" type="button">+ $5,000</button>
+                </div>
+                <p class="wallet-topups__hint text-muted">Quickly add funds before the next round begins.</p>
+
+                <div class="wallet-targets">
+                  <div class="wallet-targets__header">
+                    <span>Crash multipliers</span>
+                    <button class="button button--muted button--compact" type="button">Reset</button>
+                  </div>
+                  <div class="wallet-targets__inputs">
+                    <div class="wallet-targets__input">
+                      <label for="target-a">Side A</label>
+                      <input id="target-a" type="number" value="2.15" step="0.01" min="1" />
+                    </div>
+                    <div class="wallet-targets__input">
+                      <label for="target-b">Side B</label>
+                      <input id="target-b" type="number" value="3.45" step="0.01" min="1" />
+                    </div>
+                  </div>
+                  <div class="wallet-targets__foot">
+                    <span>Targets anchor auto cash-outs.</span>
+                    <button class="button button--muted button--compact" type="button">Apply</button>
+                  </div>
+                </div>
+
+                <div class="wallet-metrics">
+                  <div class="metric-row">
+                    <div class="metric-label">
+                      <span>Last round</span>
+                      <span class="metric-hint">Crash multiplier</span>
+                    </div>
+                    <div class="metric-value">1.84x</div>
+                  </div>
+                  <div class="metric-row">
+                    <div class="metric-label">
+                      <span>Total wagered</span>
+                      <span class="metric-hint">Today</span>
+                    </div>
+                    <div class="metric-value">$62,750.00</div>
+                  </div>
+                </div>
+
+                <div class="bet-stepper">
+                  <button class="button button--muted button--compact" type="button">-</button>
+                  <div class="bet-stepper__value">$1,000</div>
+                  <button class="button button--muted button--compact" type="button">+</button>
+                </div>
+
+                <div class="bet-presets">
+                  <button class="button button--muted" type="button">$500</button>
+                  <button class="button button--muted" type="button" data-active="true">$1,000</button>
+                  <button class="button button--muted" type="button">$2,500</button>
+                  <button class="button button--muted" type="button">$5,000</button>
+                  <button class="button button--muted" type="button">$10,000</button>
+                </div>
+
+                <div class="bet-slider">
+                  <input type="range" min="0" max="25000" value="1000" />
+                  <div class="bet-slider__scale">
+                    <span>$0</span>
+                    <span>$25,000</span>
+                  </div>
+                </div>
+
+                <div class="bet-side-overview">
+                  <div class="bet-side-chip" data-side="A">
+                    <span class="bet-side-chip__label">Selected</span>
+                    <span class="bet-side-chip__value">Side A</span>
+                    <span class="bet-side-chip__plan">Target · 2.15x</span>
+                  </div>
+                  <div class="bet-side-actions">
+                    <button class="button button--muted button--compact" type="button" data-active="true">A</button>
+                    <button class="button button--muted button--compact" type="button">B</button>
+                    <button class="button button--secondary button--compact" type="button">Swap</button>
+                  </div>
+                </div>
+
+                <div class="button-row">
+                  <button class="button button--primary" type="button">Place bet</button>
+                  <button class="button button--secondary" type="button">Cash out</button>
+                </div>
+                <span class="text-muted">Betting is available during the betting phase.</span>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Micro-bets</div>
+                  <div class="card-subtitle">Fine-tune duel combatants</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <div class="control-group">
+                  <label for="micro-step">Adjustment step</label>
+                  <input id="micro-step" type="number" value="5" min="1" max="50" />
+                </div>
+                <span class="badge badge--warning">Switch to duel mode to adjust stats</span>
+                <div class="micro-grid">
+                  <div class="micro-side">
+                    <div class="micro-side-header">
+                      <span class="badge badge--secondary">Side A</span>
+                    </div>
+                    <div class="micro-stat">
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Speed</span></div>
+                        <div class="metric-value">72</div>
+                      </div>
+                      <div class="micro-controls">
+                        <button class="button button--secondary" type="button" disabled>+5</button>
+                        <button class="button button--muted" type="button" disabled>-5</button>
+                      </div>
+                    </div>
+                    <div class="micro-stat">
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Defense</span></div>
+                        <div class="metric-value">64</div>
+                      </div>
+                      <div class="micro-controls">
+                        <button class="button button--secondary" type="button" disabled>+5</button>
+                        <button class="button button--muted" type="button" disabled>-5</button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="micro-side">
+                    <div class="micro-side-header">
+                      <span class="badge badge--secondary">Side B</span>
+                    </div>
+                    <div class="micro-stat">
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Speed</span></div>
+                        <div class="metric-value">68</div>
+                      </div>
+                      <div class="micro-controls">
+                        <button class="button button--secondary" type="button" disabled>+5</button>
+                        <button class="button button--muted" type="button" disabled>-5</button>
+                      </div>
+                    </div>
+                    <div class="micro-stat">
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Defense</span></div>
+                        <div class="metric-value">70</div>
+                      </div>
+                      <div class="micro-controls">
+                        <button class="button button--secondary" type="button" disabled>+5</button>
+                        <button class="button button--muted" type="button" disabled>-5</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <div class="column column-center">
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Game arena</div>
+                  <div class="card-subtitle">Crash Dual</div>
+                </div>
+              </div>
+              <div class="card-body arena-body">
+                <div class="arena-grid">
+                  <div class="arena-stage">
+                    <div class="arena-empty">No round data yet</div>
+                  </div>
+                  <aside class="arena-sidebar">
+                    <div class="arena-sidebar-title">Round parameters</div>
+                    <div class="arena-parameters">
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Round ID</span></div>
+                        <div class="metric-value">AB12CD34</div>
+                      </div>
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Phase</span></div>
+                        <div class="metric-value">Betting</div>
+                      </div>
+                      <div class="metric-row">
+                        <div class="metric-label"><span>Time left</span></div>
+                        <div class="metric-value">08.5s</div>
+                      </div>
+                      <div class="metric-row">
+                        <div class="metric-label">
+                          <span>A multiplier</span>
+                          <span class="metric-hint">Target 2.15x</span>
+                        </div>
+                        <div class="metric-value">1.42x</div>
+                      </div>
+                      <div class="metric-row">
+                        <div class="metric-label">
+                          <span>B multiplier</span>
+                          <span class="metric-hint">Target 3.45x</span>
+                        </div>
+                        <div class="metric-value">1.12x</div>
+                      </div>
+                    </div>
+                  </aside>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <div class="column column-right">
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Investor panel</div>
+                  <div class="card-subtitle">House overview</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <div class="metric-row">
+                  <div class="metric-label"><span>Connection</span><span class="metric-hint">Realtime updates active</span></div>
+                  <div class="metric-value"><span class="badge badge--success">Live</span></div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Bankroll</span></div>
+                  <div class="metric-value">$750,000.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Jackpot</span></div>
+                  <div class="metric-value">$42,500.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>RTP average</span></div>
+                  <div class="metric-value">98.75%</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Total rounds</span></div>
+                  <div class="metric-value">512</div>
+                </div>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Round statistics</div>
+                  <div class="card-subtitle">Performance snapshot</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <div class="metric-row">
+                  <div class="metric-label"><span>Completed rounds</span></div>
+                  <div class="metric-value">486</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Crash rounds</span></div>
+                  <div class="metric-value">310</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Duel rounds</span></div>
+                  <div class="metric-value">176</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Total wagers</span></div>
+                  <div class="metric-value">$2,450,000.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Operator profit</span></div>
+                  <div class="metric-value">$86,420.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label">
+                    <span>Operator edge</span>
+                    <span class="metric-hint">Target 4.00%</span>
+                  </div>
+                  <div class="metric-value">3.85%</div>
+                </div>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Round totals</div>
+                  <div class="card-subtitle">Crash Dual pools</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <div class="metric-row">
+                  <div class="metric-label"><span>Total pool</span></div>
+                  <div class="metric-value">$18,750.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Side A</span><span class="metric-hint">42 bets</span></div>
+                  <div class="metric-value">$10,200.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Side B</span><span class="metric-hint">35 bets</span></div>
+                  <div class="metric-value">$8,550.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Burned</span></div>
+                  <div class="metric-value">$1,200.00</div>
+                </div>
+                <div class="metric-row">
+                  <div class="metric-label"><span>Payouts</span></div>
+                  <div class="metric-value">$14,830.00</div>
+                </div>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-header">
+                <div class="card-heading">
+                  <div class="card-title">Events</div>
+                  <div class="card-subtitle">Latest activity</div>
+                </div>
+              </div>
+              <div class="card-body">
+                <ul class="event-list">
+                  <li class="event-item">
+                    <span class="event-time">19:42:18</span>
+                    <span class="event-text">Bet placed · $1,000 on side A (target 2.15x)</span>
+                  </li>
+                  <li class="event-item">
+                    <span class="event-time">19:41:52</span>
+                    <span class="event-text">Crash round started · Phase betting</span>
+                  </li>
+                  <li class="event-item">
+                    <span class="event-time">19:41:10</span>
+                    <span class="event-text">Wallet updated · $25,000.00</span>
+                  </li>
+                </ul>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <footer class="app-footer">
+        <div class="app-footer__inner">
+          <span class="app-footer__brand">Clash Dual playground</span>
+          <span class="app-footer__note">Simulation environment for crash and duel mechanics.</span>
+        </div>
+      </footer>
+
+      <div class="build-indicator">
+        <span>Build</span>
+        <span class="build-indicator__commit">local</span>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Inline the complete Clash Dual styling directly into `index.html` for a standalone page.
- Replace the React root placeholder with full static markup covering the header, main dashboard, cards, and footer content.
- Add a build badge style to keep the commit indicator consistent with the new static layout.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52fee2c0083209be55d4420b230de