### PR TITLE
Align WebSocket server path with client

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -624,7 +624,7 @@ function handleFatalError(error: unknown) {
 
 httpServer.on('error', handleFatalError);
 
-const wss = new WebSocketServer({ server: httpServer });
+const wss = new WebSocketServer({ server: httpServer, path: '/ws' });
 wss.on('error', handleFatalError);
 
 httpServer.listen(PORT, () => {

--- a/server/test/bets-idempotency.test.ts
+++ b/server/test/bets-idempotency.test.ts
@@ -115,7 +115,7 @@ test('server rejects duplicate bet ids from the same player', async (t) => {
 
   await once(server.stdout, 'data');
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   t.after(() => ws.close());
   await once(ws, 'open');
   const queue = createMessageQueue(ws);

--- a/server/test/duel-bet-validation.test.js
+++ b/server/test/duel-bet-validation.test.js
@@ -60,7 +60,7 @@ test('rejects duel bets without a side without charging the wallet', async (t) =
 
   await once(server.stdout, 'data');
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   t.after(() => {
     ws.close();
   });

--- a/server/test/rate-limit.test.ts
+++ b/server/test/rate-limit.test.ts
@@ -73,7 +73,7 @@ test('enforces per-user rate limits and resets tokens after interval', async (t)
 
   await once(server.stdout, 'data');
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   t.after(() => {
     ws.close();
   });

--- a/server/test/server-port-fallback.test.js
+++ b/server/test/server-port-fallback.test.js
@@ -29,7 +29,7 @@ test('uses fallback port when PORT env var is invalid', async (t) => {
     `Expected startup log to reference fallback port ${FALLBACK_PORT}, got: ${startupLog}`
   );
 
-  const ws = new WebSocket(`ws://127.0.0.1:${FALLBACK_PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${FALLBACK_PORT}/ws`);
   t.after(() => {
     ws.close();
   });

--- a/server/test/ws-auth.test.js
+++ b/server/test/ws-auth.test.js
@@ -70,7 +70,7 @@ test('allows betting and cashing out on the same authenticated socket', async (t
 
   await once(server.stdout, 'data');
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   t.after(() => {
     ws.close();
   });

--- a/server/test/ws-invalid-payload.test.js
+++ b/server/test/ws-invalid-payload.test.js
@@ -65,7 +65,7 @@ test('rejects invalid payloads with an error and logs origin', async (t) => {
     stderrOutput += chunk.toString();
   });
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   t.after(() => {
     ws.close();
   });

--- a/server/test/ws-reconnect.test.js
+++ b/server/test/ws-reconnect.test.js
@@ -68,7 +68,7 @@ test('cleans up sockets after disconnects and keeps streaming snapshots', async 
   });
 
   for (let i = 0; i < 10; i++) {
-    const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+    const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
     await once(ws, 'open');
     const messages = createMessageQueue(ws);
 
@@ -85,7 +85,7 @@ test('cleans up sockets after disconnects and keeps streaming snapshots', async 
     });
   }
 
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
   await once(ws, 'open');
   const messages = createMessageQueue(ws);
   ws.send(JSON.stringify({ t: 'auth' }));


### PR DESCRIPTION
## Summary
- configure the WebSocket server to listen on the /ws path expected by the frontend
- update integration tests to connect using the /ws endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5362417e88320b7470c4a417dcdb2