### PR TITLE
Fix crash canvas block sizing

### DIFF
--- a/client/src/games/CrashDualCanvas.tsx
+++ b/client/src/games/CrashDualCanvas.tsx
@@ -579,5 +579,5 @@ export default function CrashDualCanvas({ mA, mB, targetA, targetB, phase }: Cra
     };
   }, []);
 
-  return <canvas ref={ref} width={900} height={460} style={{ width: '100%', height: '100%', display: 'block' }} />;
+  return <canvas ref={ref} width={900} height={460} style={{ width: '900px', height: '460px', display: 'block' }} />;
 }

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -945,8 +945,8 @@ input[type='range'] {
 }
 
 .arena-stage canvas {
-  width: 100%;
-  height: auto;
+  width: 900px;
+  height: 460px;
   border-radius: calc(var(--radius-lg) - 6px);
   border: 1px solid var(--color-canvas-border);
   background: var(--color-canvas);


### PR DESCRIPTION
## Summary
- set the crash arena canvas to a fixed 900×460 layout instead of stretching to fill the container
- keep the component inline styles consistent with the new fixed size so the drawing math still matches the DOM canvas size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d663fdad2c8320bd7b2c56097e7676