### PR TITLE
Add draggable dashboard layout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "clash-dual-client",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -306,6 +309,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3240,6 +3296,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,11 @@
     "lint": "eslint --config ../.eslintrc.cjs --resolve-plugins-relative-to . \"src/**/*.{ts,tsx}\" --max-warnings=0"
   },
 "dependencies": {
-"react": "^18.3.1",
-"react-dom": "^18.3.1"
+  "@dnd-kit/core": "^6.3.1",
+  "@dnd-kit/sortable": "^7.0.2",
+  "@dnd-kit/utilities": "^3.2.2",
+  "react": "^18.3.1",
+  "react-dom": "^18.3.1"
 },
   "devDependencies": {
     "@types/react": "^18.3.10",

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -379,6 +379,7 @@ body::before {
   flex-direction: column;
   gap: var(--gap-lg);
   min-width: 0;
+  position: relative;
 }
 
 .column-left {
@@ -391,6 +392,49 @@ body::before {
 
 .column-right {
   grid-column: 3;
+}
+
+.draggable-panel {
+  cursor: grab;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  will-change: transform;
+}
+
+.draggable-panel:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 6px;
+}
+
+.draggable-panel[data-dragging] {
+  cursor: grabbing;
+  opacity: 0.9;
+  box-shadow: var(--shadow-strong);
+}
+
+.draggable-panel[data-dragging] .card {
+  pointer-events: none;
+}
+
+.draggable-panel[data-sorting]:not([data-dragging]) {
+  transition: transform 0.2s ease;
+}
+
+.column[data-dropping] {
+  background: linear-gradient(145deg, rgba(124, 109, 255, 0.08), rgba(77, 208, 255, 0.06));
+  border-radius: var(--radius-lg);
+  outline: 1px dashed rgba(124, 109, 255, 0.4);
+  outline-offset: 8px;
+}
+
+.column-placeholder {
+  height: 12px;
+  pointer-events: none;
+}
+
+.column[data-dropping] .column-placeholder {
+  height: 32px;
+  background: linear-gradient(135deg, rgba(124, 109, 255, 0.18), rgba(77, 208, 255, 0.12));
+  border-radius: var(--radius-md);
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add @dnd-kit dependencies and column/panel metadata for the dashboard layout
- persist column order in localStorage and expose all cards via a reusable panels map
- wrap the layout with DndContext/Sortable panels and add drag state styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfc3448c1c83209be50c3e7ee9ae25