### PR TITLE
Refactor App layout to styled components

### DIFF
--- a/client/src/games/DuelABPanel.tsx
+++ b/client/src/games/DuelABPanel.tsx
@@ -1,5 +1,35 @@
+import styled from 'styled-components';
 import { Badge, type BadgeTone } from '../ui/Badge';
 import { MetricRow } from '../ui/MetricRow';
+
+const DuelArena = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+`;
+
+const DuelArenaRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--gap-md);
+`;
+
+const DuelArenaSide = styled.div`
+  background: var(--color-panel-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-panel-border-strong);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+`;
+
+const DuelArenaStatus = styled.div`
+  display: flex;
+  gap: var(--gap-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+`;
 
 const phaseTone: Record<string, BadgeTone> = {
   betting: 'primary',
@@ -17,24 +47,24 @@ interface DuelABPanelProps {
 
 export default function DuelABPanel({ micro, winner, phase }: DuelABPanelProps) {
   return (
-    <div className="duel-arena">
-      <div className="duel-arena-row">
+    <DuelArena>
+      <DuelArenaRow>
         {(['A', 'B'] as const).map((side) => (
-          <div key={side} className="duel-arena-side">
+          <DuelArenaSide key={side}>
             <Badge tone="secondary">Side {side}</Badge>
             <MetricRow label="Speed" value={micro?.[side]?.speed ?? 0} />
             <MetricRow label="Defense" value={micro?.[side]?.defense ?? 0} />
-          </div>
+          </DuelArenaSide>
         ))}
-      </div>
-      <div className="duel-arena-status">
+      </DuelArenaRow>
+      <DuelArenaStatus>
         <Badge tone={phaseTone[phase] ?? 'muted'}>Phase: {phase}</Badge>
         {winner ? (
           <Badge tone="success">Winner: {winner}</Badge>
         ) : (
           <Badge tone="muted">Awaiting result</Badge>
         )}
-      </div>
-    </div>
+      </DuelArenaStatus>
+    </DuelArena>
   );
 }


### PR DESCRIPTION
## Summary
- replace class-based layout in App with scoped styled components for containers, controls, and responsive behaviour
- introduce reusable button, segmented, and control group primitives along with wallet, bet, arena, and event specific styling
- update DuelABPanel to match the new styled-component approach for duel arena presentation

## Testing
- pnpm -C client lint

------
https://chatgpt.com/codex/tasks/task_e_68dfd7fa327883208e565fae63d1e17a