### PR TITLE
Refine duel arena styling

### DIFF
--- a/client/src/games/DuelABPanel.tsx
+++ b/client/src/games/DuelABPanel.tsx
@@ -2,19 +2,19 @@ import styled from 'styled-components';
 import { Badge, type BadgeTone } from '../ui/Badge';
 import { MetricRow } from '../ui/MetricRow';
 
-const DuelArena = styled.div`
+const ArenaContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);
 `;
 
-const DuelArenaRow = styled.div`
+const ArenaSidesRow = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: var(--gap-md);
 `;
 
-const DuelArenaSide = styled.div`
+const ArenaSideCard = styled.div`
   background: var(--color-panel-alt);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-panel-border-strong);
@@ -24,7 +24,7 @@ const DuelArenaSide = styled.div`
   gap: var(--gap-sm);
 `;
 
-const DuelArenaStatus = styled.div`
+const ArenaStatusPanel = styled.div`
   display: flex;
   gap: var(--gap-sm);
   flex-wrap: wrap;
@@ -47,24 +47,24 @@ interface DuelABPanelProps {
 
 export default function DuelABPanel({ micro, winner, phase }: DuelABPanelProps) {
   return (
-    <DuelArena>
-      <DuelArenaRow>
+    <ArenaContainer>
+      <ArenaSidesRow>
         {(['A', 'B'] as const).map((side) => (
-          <DuelArenaSide key={side}>
+          <ArenaSideCard key={side}>
             <Badge tone="secondary">Side {side}</Badge>
             <MetricRow label="Speed" value={micro?.[side]?.speed ?? 0} />
             <MetricRow label="Defense" value={micro?.[side]?.defense ?? 0} />
-          </DuelArenaSide>
+          </ArenaSideCard>
         ))}
-      </DuelArenaRow>
-      <DuelArenaStatus>
+      </ArenaSidesRow>
+      <ArenaStatusPanel>
         <Badge tone={phaseTone[phase] ?? 'muted'}>Phase: {phase}</Badge>
         {winner ? (
           <Badge tone="success">Winner: {winner}</Badge>
         ) : (
           <Badge tone="muted">Awaiting result</Badge>
         )}
-      </DuelArenaStatus>
-    </DuelArena>
+      </ArenaStatusPanel>
+    </ArenaContainer>
   );
 }

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -878,35 +878,6 @@ input[type='range'] {
   gap: var(--gap-sm);
 }
 
-.duel-arena {
-  display: flex;
-  flex-direction: column;
-  gap: var(--gap-md);
-}
-
-.duel-arena-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: var(--gap-md);
-}
-
-.duel-arena-side {
-  background: var(--color-panel-alt);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-panel-border-strong);
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--gap-sm);
-}
-
-.duel-arena-status {
-  display: flex;
-  gap: var(--gap-sm);
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
 .event-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- replace the duel arena layout markup with dedicated styled components for the container, side cards, and status bar
- remove the obsolete global CSS selectors now covered by the panel components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e37804c7bc8320b73e19550a8e26e8