### PR TITLE
Fix crash bankroll settlement timing

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -61,7 +61,6 @@ function tryCashoutCrash(uid: string) {
         const win = b.amount * b.cashoutAt;
         const rake = win * 0.02;
         pay(uid, win - rake);
-        bankroll -= (win - rake);
         done = true;
       }
     }
@@ -94,9 +93,10 @@ setInterval(() => {
     if (crash.phase === 'intermission') {
       const endA = crash.targetA;
       const endB = crash.targetB;
-      let burned = 0, payouts = 0;
+      let burned = 0, payouts = 0, totalStakes = 0;
       for (const [list, final] of [[crash.betsA, endA],[crash.betsB, endB]] as const) {
         for (const b of list) {
+          totalStakes += b.amount;
           if (b.cashedOut && b.cashoutAt && b.cashoutAt < final) {
             const win = b.amount * b.cashoutAt;
             const rake = win * 0.02;
@@ -106,7 +106,7 @@ setInterval(() => {
           }
         }
       }
-      bankroll += burned - payouts;
+      bankroll += totalStakes - payouts;
       jackpot += Math.max(0, burned * 0.01);
       rounds += 1;
       crash = newCrashRound();

--- a/server/test/crash-bankroll.test.js
+++ b/server/test/crash-bankroll.test.js
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import WebSocket from 'ws';
+
+const PORT = 19083;
+
+function createMessageQueue(ws) {
+  const queue = [];
+  const waiters = new Set();
+
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data.toString());
+    for (const waiter of waiters) {
+      if (waiter.predicate(msg)) {
+        waiters.delete(waiter);
+        clearTimeout(waiter.timer);
+        waiter.resolve(msg);
+        return;
+      }
+    }
+    queue.push(msg);
+  });
+
+  async function waitFor(predicate, timeout = 12000) {
+    for (let i = 0; i < queue.length; i++) {
+      const msg = queue[i];
+      if (predicate(msg)) {
+        queue.splice(i, 1);
+        return msg;
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        predicate,
+        resolve,
+        timer: setTimeout(() => {
+          waiters.delete(waiter);
+          reject(new Error('Timed out waiting for message'));
+        }, timeout)
+      };
+      waiters.add(waiter);
+    });
+  }
+
+  return { waitFor };
+}
+
+function getCrashBet(snapshot, uid) {
+  const crash = snapshot?.crash;
+  if (!crash) return undefined;
+  for (const list of [crash.betsA ?? [], crash.betsB ?? []]) {
+    const bet = list.find((b) => b.uid === uid);
+    if (bet) return bet;
+  }
+  return undefined;
+}
+
+test('bankroll only changes by stakes minus payouts after crash cashout', async (t) => {
+  const server = spawn('node', ['dist/server.js'], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  t.after(() => {
+    server.kill('SIGTERM');
+  });
+
+  await once(server.stdout, 'data');
+
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  t.after(() => {
+    ws.close();
+  });
+
+  await once(ws, 'open');
+  const messages = createMessageQueue(ws);
+
+  ws.send(JSON.stringify({ t: 'auth' }));
+  const hello = await messages.waitFor((msg) => msg.t === 'hello');
+  assert.ok(typeof hello.uid === 'string' && hello.uid.length > 0, 'should receive uid');
+
+  const initialBankroll = hello.snapshot?.bankroll;
+  assert.equal(typeof initialBankroll, 'number', 'should receive initial bankroll');
+
+  const initialCrashId = hello.snapshot?.crash?.id;
+  assert.ok(initialCrashId, 'should receive crash id');
+
+  const betAmount = 100;
+  ws.send(JSON.stringify({ t: 'bet', amount: betAmount, side: 'A' }));
+
+  await messages.waitFor((msg) => {
+    if (msg.t !== 'snapshot') return false;
+    const bet = getCrashBet(msg.snapshot, hello.uid);
+    return !!bet && bet.amount === betAmount;
+  }, 8000);
+
+  await messages.waitFor((msg) => msg.t === 'snapshot' && msg.snapshot?.crash?.phase === 'running', 12000);
+
+  ws.send(JSON.stringify({ t: 'cashout' }));
+
+  const cashedSnapshot = await messages.waitFor((msg) => {
+    if (msg.t !== 'snapshot') return false;
+    const bet = getCrashBet(msg.snapshot, hello.uid);
+    return !!bet && bet.cashedOut === true && typeof bet.cashoutAt === 'number';
+  }, 12000);
+
+  const cashedBet = getCrashBet(cashedSnapshot.snapshot, hello.uid);
+  assert.ok(cashedBet?.cashedOut, 'bet should be marked cashed out');
+  assert.ok(typeof cashedBet.cashoutAt === 'number' && cashedBet.cashoutAt > 0, 'cashout multiplier should be recorded');
+
+  const win = betAmount * cashedBet.cashoutAt;
+  const rake = win * 0.02;
+  const payout = win - rake;
+  const totalStakes = betAmount;
+
+  const finalSnapshot = await messages.waitFor((msg) => {
+    if (msg.t !== 'snapshot') return false;
+    const crash = msg.snapshot?.crash;
+    return crash?.phase === 'betting' && crash.id !== initialCrashId;
+  }, 36000);
+
+  const finalBankroll = finalSnapshot.snapshot?.bankroll;
+  const expectedBankroll = initialBankroll + totalStakes - payout;
+
+  assert.ok(Math.abs(finalBankroll - expectedBankroll) < 1e-6, `expected bankroll ${expectedBankroll}, got ${finalBankroll}`);
+});


### PR DESCRIPTION
## Summary
- defer bankroll adjustments for crash cashouts until intermission and settle using total stakes instead of only burned bets
- keep house profit equal to stakes minus payouts during crash settlement
- add an integration test covering crash bankroll after a cashout

## Testing
- npm run build
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68e39693f9d483208f2a5259bfc9acf4